### PR TITLE
Upload the most recent successful build when drafting a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Attach latest build to Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  attach-artifact:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download latest build artifact
+        uses: dawidd6/action-download-artifact@v8
+        with:
+          workflow: build.yml
+          workflow_conclusion: success
+          name: GICutscenesUI
+      - name: Upload to Release
+        uses: xresloader/upload-to-github-release@v1
+        with:
+          file: "GICutscenesUI.exe"
+          update_latest_release: true

--- a/GICutscenesUI/web/locales/zh-hans.json
+++ b/GICutscenesUI/web/locales/zh-hans.json
@@ -47,6 +47,7 @@
 	"subtitles_text_color": "文本颜色：",
 	"subtitles_outline_color": "轮廓颜色：",
 	"subtitles_outline_width": "轮廓宽度：",
+	"subtitles_letter_spacing": "字符间距：",
 	"subtitles_bold": "粗体",
 	"subtitles_italic": "斜体",
 


### PR DESCRIPTION
I assume that you only need to upload the artifact generated by the build workflow to the release each time you manually create a new Release. Based on this, this new workflow will automatically download and upload the most recently successfully built exe file after releasing, attaching it to the release.
Please remember to enable read and write permissions for Actions in repo settings (**Settings > Actions > General > Workflow permissions**), and ensure that the build workflow completes successfully before drafting the release.


By the way, the zh-hans translation has also been updated. :)