### PR TITLE
Allow manual triggering for release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Attach latest build to Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   attach-artifact:
@@ -19,4 +20,5 @@ jobs:
         uses: xresloader/upload-to-github-release@v1
         with:
           file: "GICutscenesUI.exe"
+          overwrite: true
           update_latest_release: true


### PR DESCRIPTION
It can be manually triggered via https://github.com/SuperZombi/GICutscenesUI/actions/workflows/release.yml after merging into main branch.